### PR TITLE
fix: mark arch and os as required.

### DIFF
--- a/Formula/tabby.rb
+++ b/Formula/tabby.rb
@@ -2,11 +2,10 @@ class Tabby < Formula
   desc "Tabby: AI Coding Assitatnt"
   homepage "https://github.com/TabbyML/tabby"
 
-  on_macos do
-    on_arm do
-      head "https://github.com/TabbyML/tabby/releases/download/nightly/tabby_aarch64-apple-darwin"
-    end
-  end
+  depends_on :macos
+  depends_on arch: :arm
+  
+  head "https://github.com/TabbyML/tabby/releases/download/nightly/tabby_aarch64-apple-darwin"
 
   def install
     bin.install "tabby_aarch64-apple-darwin" => "tabby"


### PR DESCRIPTION
> brew info tabby
<img width="537" alt="Screenshot 2023-09-08 at 10 46 36" src="https://github.com/TabbyML/homebrew-tabby/assets/13573879/78ed81b2-2975-47ec-9088-00bd35d83671">

> brew install tabby
<img width="531" alt="Screenshot 2023-09-08 at 10 48 58" src="https://github.com/TabbyML/homebrew-tabby/assets/13573879/59ac5580-55bb-4101-938a-7c408f8117de">
