### PR TITLE
chore: release v0.24.0-rc.0

### DIFF
--- a/Formula/tabby-rc.rb
+++ b/Formula/tabby-rc.rb
@@ -2,10 +2,12 @@ class TabbyRc < Formula
   desc "Tabby: AI Coding Assistant"
   homepage "https://github.com/TabbyML/tabby"
 
+  version "0.24.0-rc.0"
+
   depends_on :macos
   depends_on arch: :arm
 
-  url "https://github.com/TabbyML/tabby/releases/download/v0.23.0-rc.1/tabby_aarch64-apple-darwin.tar.gz"
+  url "https://github.com/TabbyML/tabby/releases/download/v#{version}/tabby_aarch64-apple-darwin.tar.gz"
 
   def install
     bin.install "tabby" => "tabby"


### PR DESCRIPTION
Release v0.24.0-rc.0

![CleanShot 2025-01-17 at 20 27 34@2x](https://github.com/user-attachments/assets/c2c44313-a95c-4d99-9d97-40fc9bfa83fe)
