### PR TITLE
chore: release v0.26.0

### DIFF
--- a/Formula/tabby.rb
+++ b/Formula/tabby.rb
@@ -2,7 +2,7 @@ class Tabby < Formula
   desc "Tabby: AI Coding Assistant"
   homepage "https://github.com/TabbyML/tabby"
 
-  version "0.25.1"
+  version "0.26.0"
 
   depends_on :macos
   depends_on arch: :arm


### PR DESCRIPTION
![CleanShot 2025-03-16 at 14 33 54@2x](https://github.com/user-attachments/assets/c047743a-d7f6-44cb-aa9c-44345157ca44)
