### PR TITLE
feat(next): inital next alpha support

### DIFF
--- a/Formula/tabby-next.rb
+++ b/Formula/tabby-next.rb
@@ -1,0 +1,17 @@
+class TabbyRc < Formula
+  desc "Tabby: AI Coding Assistant"
+  homepage "https://github.com/TabbyML/tabby"
+
+  version "alpha"
+
+  depends_on :macos
+  depends_on arch: :arm
+
+  url "https://github.com/TabbyML/tabby/releases/download/next-#{version}/tabby_aarch64-apple-darwin.tar.gz"
+
+  def install
+    bin.install "tabby" => "tabby"
+    bin.install "llama-server" => "llama-server"
+  end
+end
+


### PR DESCRIPTION
1. llama-server is still installed to keep compatibility currently since previous feature still exists.
2. installing by `brew install tabbyml/tabby/tabby-next`